### PR TITLE
Improve performance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 Catwalk = "860e6890-8a08-4313-9643-fcac6eb69798"
+Folds = "41a02a25-b8f0-4f67-bc48-60067656b558"
 Transducers = "28d57a85-8fef-5791-bfe6-a80928e7c999"
 
 [compat]

--- a/examples/sum.jl
+++ b/examples/sum.jl
@@ -1,9 +1,15 @@
 using BenchmarkTools
+using Catwalk
 using Folds
 using FoldsCatwalk
 using Transducers
 
 type_instability(x) = Val(round(Int, 2x))
+
+# This version emphasizes the possible gain better:
+#vals=[Val(i) for i= 1:100]
+#type_instability(x) = vals[abs(round(Int, 4x)) % length(vals) + 1]
+
 asint(::Val{x}) where {x} = x::Int
 
 function sum_baseline(xs)
@@ -16,9 +22,28 @@ function sum_catwalk(xs)
     Folds.sum(itr, CatwalkEx())
 end
 
-function demo_sum()
-    xs = randn(1000_000)
-    @assert sum_baseline(xs) == sum_catwalk(xs)
-    @btime sum_baseline($xs)
-    @btime sum_catwalk($xs)
+function sum_catwalk_tuned(xs)
+    itr = xs |> Map(type_instability) |> OptimizeInner() do 
+        boost = Catwalk.CallBoost(:next;
+                    optimizer = Catwalk.TopNOptimizer(15),
+                    profilestrategy = Catwalk.SparseProfile(0))
+        jit = Catwalk.JIT(boost; explorertype = Catwalk.NoExplorer)
+    end |> Map(asint)
+    Folds.sum(itr, CatwalkEx())
+end
+
+function demo_sum(n=20_000_000)
+    xs = randn(n)
+
+    println("Baseline:")
+    baseline_result = @btime sum_baseline($xs)
+
+    println("Catwalk defaults:")
+    catwalk_result = @btime sum_catwalk($xs)
+
+    println("Catwalk tuned:")
+    catwalk_tuned_result = @btime sum_catwalk_tuned($xs)
+
+    @assert baseline_result == catwalk_result
+    @assert baseline_result == catwalk_tuned_result
 end


### PR DESCRIPTION
A possible fix of the missing performance gain.

```
julia> demo_sum()
Baseline:
  4.649 s (0 allocations: 0 bytes)
Catwalk defaults:
  4.210 s (5607369 allocations: 116.47 MiB)
Catwalk tuned:
  4.007 s (2775829 allocations: 55.60 MiB)
```

The problem was that

```julia
@inline next(rf::R_{Map}, result, input) = next(inner(rf), result, xform(rf).f(input))
```

was called before the Catwalked method of `next`, resulting in a non-jitted dynamic dispatch.

I am not sure though if what I did is reasonable in the larger context, but I hope you can fix it based on this.

Also, the default batch size was too small, so I have increased it to 1e6, which may be more than ideal, more tests are needed.

When testing with `@btime`, initial overhead should be small, but I see a small amount of compilation in every Catwalked run, thats why the tested runtimes have to be several seconds. I will check that, but I like to test cold runs with `@time` anyway, because Catwalk adds significant compiling overhead, and not measuring it seems unfair.
